### PR TITLE
Update an included filename extension to build on Noetic

### DIFF
--- a/canopen_motor_node/include/canopen_motor_node/handle_layer.h
+++ b/canopen_motor_node/include/canopen_motor_node/handle_layer.h
@@ -7,7 +7,7 @@
 #include <atomic>
 #include <functional>
 #include <boost/thread/mutex.hpp>
-#include <filters/filter_chain.h>
+#include <filters/filter_chain.hpp>
 #include <hardware_interface/joint_command_interface.h>
 #include <hardware_interface/joint_state_interface.h>
 #include <joint_limits_interface/joint_limits_interface.h>


### PR DESCRIPTION
This PR removes the following warning:

```
Warnings   << canopen_motor_node:make CATKIN_WS/logs/canopen_motor_node/build.make.000.log                                                                                       
In file included from CATKIN_WS/src/ros_canopen/canopen_motor_node/include/canopen_motor_node/handle_layer.h:10,
                 from CATKIN_WS/src/ros_canopen/canopen_motor_node/src/motor_chain.cpp:3:
/opt/ros/noetic/include/filters/filter_chain.h:40:2: warning: #warning Including header <filters/filter_chain.h> is deprecated, include <filters/filter_chain.hpp> instead. [-Wcpp]
   40 | #warning Including header <filters/filter_chain.h> is deprecated, \
      |  ^~~~~~~
In file included from CATKIN_WS/src/ros_canopen/canopen_motor_node/include/canopen_motor_node/handle_layer.h:10,
                 from CATKIN_WS/src/ros_canopen/canopen_motor_node/src/handle_layer.cpp:2:
/opt/ros/noetic/include/filters/filter_chain.h:40:2: warning: #warning Including header <filters/filter_chain.h> is deprecated, include <filters/filter_chain.hpp> instead. [-Wcpp]
   40 | #warning Including header <filters/filter_chain.h> is deprecated, \
      |  ^~~~~~~
```